### PR TITLE
corpus_iri removed from the queries

### DIFF
--- a/cqp4rdf/cqp2sparql.py
+++ b/cqp4rdf/cqp2sparql.py
@@ -159,7 +159,6 @@ class CQP2SPARQLTransformer(lark.Transformer):
     sparql_tmpl = """%s
 
 SELECT DISTINCT {variables}
-FROM <%s>
 WHERE
 {{
 {conditions}
@@ -176,7 +175,7 @@ WHERE
     def __init__(self, prefixes, corpus_iri):
         super(CQP2SPARQLTransformer, self).__init__()
 
-        self.sparql_tmpl = self.sparql_tmpl % (prefixes, corpus_iri)
+        self.sparql_tmpl = self.sparql_tmpl % (prefixes)
         
         # A list of all the variables (both named and var_N)
         self.tokens = []

--- a/cqp4rdf/main.py
+++ b/cqp4rdf/main.py
@@ -52,7 +52,6 @@ def allChidren(parent):
     sparql = """{prefixes}
 
     SELECT DISTINCT ?word ?link
-    FROM <{corpus_iri}>
     WHERE
     {{
         ?link a nif:Word .
@@ -106,7 +105,6 @@ def word_info():
     sparql = """{prefixes}
 
     SELECT DISTINCT ?pred ?val 
-    FROM <{corpus_iri}>
     WHERE
     {{
         <{word_uri}> ?pred ?val .


### PR DESCRIPTION
Have removed Corpus IRI from the queries, have removed since we are querying from the local fuseki server and the SPARQL endpoint contains many files and each file has its own prefix. So, it won't be possible to search using a common prefix.