### PR TITLE
dockerfile and docker-compose added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:latest
+
+RUN apk add --no-cache python3-dev 
+RUN pip3 install --upgrade pip
+COPY ./requirements.txt /tmp/
+RUN pip3 install -r /tmp/requirements.txt
+
+RUN mkdir /cqp4rdf
+COPY ./cqp4rdf /cqp4rdf/cqp4rdf
+COPY ./cqp.ebnf /cqp4rdf
+
+WORKDIR /cqp4rdf/cqp4rdf/
+
+EXPOSE 8088
+
+ENTRYPOINT ["python3"]
+CMD ["main.py"]

--- a/cqp4rdf/config.docker.yaml
+++ b/cqp4rdf/config.docker.yaml
@@ -3,9 +3,9 @@ default: cdli
 n_results: 50
 api:
   port: 8088
-  host: 127.0.0.1
+  host: 0.0.0.0
 sparql:
-  host: http://127.0.0.1:3030/
+  host: http://fuseki:3030/
   endpoint: test/query
 corpora:
   ud-en:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  fuseki:
+    image: stain/jena-fuseki
+    volumes:
+      - fuseki_data:/fuseki
+    ports:
+      - 3030:3030
+    environment:
+      - ADMIN_PASSWORD=pw123
+
+  cqp4rdf:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8088:8088
+    depends_on:
+      - fuseki
+    environment:
+      - FLASK_ENV= development
+volumes:
+  fuseki_data:


### PR DESCRIPTION
This PR adds a docker file and docker-compose file so that everything can be run without any dependencies.

This PR has the following updates:-
- Adds `Dockerfile` and `docker-compose.yaml`
- Also, since the config file needs to be a bit different for docker and running independently, therefore added a new `config.docker.yaml`, which would be an example for running the docker container.
- Also, `cdli` has been added as the default dataset, since a lot has been added for that database