### PR TITLE
quick fix to enable CQP without consecutive condition for tokens

### DIFF
--- a/cqp.ebnf
+++ b/cqp.ebnf
@@ -127,6 +127,7 @@ constraints: c_disjunc	 	 -> constraints
 
 // word_param: var_name "." c_prefix ":" c_param	-> term
 word_param: var_name "." c_param			-> term
+    | var_name -> term
 // v_name: CNAME								-> v_name
 c_param: TOKEN 								-> c_param
 // c_prefix: CNAME								-> c_prefix

--- a/cqp4rdf/config.docker.yaml
+++ b/cqp4rdf/config.docker.yaml
@@ -15,7 +15,11 @@ sparql:
   host: http://fuseki:3030/
   # here "test" is the dataset name which we specified 
   endpoint: test/query
-# defining different corpus 
+# defining search options
+search:
+  # this setting defines if two tokens are required to be adjacent
+  keep-precedence: false
+# defining different corpus
 corpora:
   # name of the corpus 
   ud-en:

--- a/cqp4rdf/config.example.yaml
+++ b/cqp4rdf/config.example.yaml
@@ -14,6 +14,10 @@ sparql:
   host: http://127.0.0.1:3030/
   # here "test" is the dataset name which we specified 
   endpoint: test/query
+# defining search options
+search:
+  # this setting defines if two tokens are required to be adjacent
+  keep-precedence: true
 # defining different corpus 
 corpora:
   # name of the corpus 

--- a/cqp4rdf/main.py
+++ b/cqp4rdf/main.py
@@ -168,14 +168,14 @@ def query():
     logging.info(cqp)
     logging.info(parser.parse(cqp).pretty())
 
-    transformer = cqp2sparql.CQP2SPARQLTransformer(prefixes, corpus_iri)
+    transformer = cqp2sparql.CQP2SPARQLTransformer(prefixes, corpus_iri, config.get('search', {}))
     trees = cqp2sparql.unfold(cqp2sparql.negless(parser.parse(cqp)))
 
     sparqls = []
 
     for tree in trees:
         # it's important not to reuse the transformers 
-        transformer = cqp2sparql.CQP2SPARQLTransformer(prefixes, corpus_iri)
+        transformer = cqp2sparql.CQP2SPARQLTransformer(prefixes, corpus_iri, config.get('search', {}))
         sparqls += [transformer.transform(tree)]
         
     sparql = cqp2sparql.concat(sparqls) + "ORDER BY ?links OFFSET " + str((page-1) * config['n_results']) + " LIMIT " + str(config['n_results']+1)


### PR DESCRIPTION
A simple fix that provides a configurable search option that enables or disable consecutive condition for adjacent tokens